### PR TITLE
miscellaneous fixes for date range handling

### DIFF
--- a/example/lib/grid/image_grid_page.dart
+++ b/example/lib/grid/image_grid_page.dart
@@ -42,9 +42,12 @@ class _ImageGridPageState extends State<ImageGridPage> {
     final start = widget.range.start;
     final end = widget.range.end;
 
+    final startDate = DateTime(start.year, start.month, start.day);
+    final endDate = DateTime(end.year, end.month, end.day + 1, 0, 0, end.second - 1);
+
     final files = await MediaPickerBuilder.getMediaAssets(
-      start: start,
-      end: end,
+      start: startDate,
+      end: endDate,
       types: [MediaType.video, MediaType.image],
     );
 

--- a/ios/Classes/MediaFetcher.swift
+++ b/ios/Classes/MediaFetcher.swift
@@ -29,21 +29,12 @@ class MediaFetcher {
         
         var predicates: [NSPredicate] = []
         
-        let calendar = Calendar.current
-        
         if let startDate = start {
-            let date = calendar.startOfDay(for: startDate)
-            
-            predicates.append(NSPredicate(format: "creationDate > %@", date as CVarArg))
+            predicates.append(NSPredicate(format: "creationDate > %@", startDate as CVarArg))
         }
+        
         if let endDate = end {
-            var components = DateComponents()
-            components.day = 1
-            components.second = -1
-            
-            let date = calendar.date(byAdding: components, to: endDate)!
-            
-            predicates.append(NSPredicate(format: "creationDate < %@", date as CVarArg))
+            predicates.append(NSPredicate(format: "creationDate < %@", endDate as CVarArg))
         }
         
         var typePredicates: [NSPredicate] = []

--- a/ios/Classes/SwiftMediaPickerBuilderPlugin.swift
+++ b/ios/Classes/SwiftMediaPickerBuilderPlugin.swift
@@ -84,8 +84,7 @@ public class SwiftMediaPickerBuilderPlugin: NSObject, FlutterPlugin {
             }
             
             MediaFetcher.getMediaFile(for: asset) { (progress) in
-                print("Swift Progress: \(progress)")
-                try? self.sendEvent(event: GetMediaFileEvent(type: .progress, fileId: fileId, progress: progress, file: nil))
+                try? self.sendEvent(event: GetMediaFileEvent(fileId: fileId, progress: progress))
             } completion: { (file) in
                 let encoder = JSONEncoder()
                 do {
@@ -225,15 +224,8 @@ public class SwiftMediaPickerBuilderPlugin: NSObject, FlutterPlugin {
 }
 
 struct GetMediaFileEvent: Encodable {
-    let type: EventType
     let fileId: String
     let progress: Double?
-    let file: MediaFile?
-    
-    enum EventType: String, Encodable {
-        case progress
-        case finished
-    }
 }
 
 extension SwiftMediaPickerBuilderPlugin: FlutterStreamHandler {

--- a/lib/media_picker_builder.dart
+++ b/lib/media_picker_builder.dart
@@ -22,11 +22,14 @@ class MediaPickerBuilder {
     assert(start != null);
     assert(end != null);
 
+    final startUtc = start.toUtc();
+    final endUtc = end.toUtc();
+
     final String json = await _channel.invokeMethod(
       "v2/getMediaAssets",
       {
-        "startDate": start.millisecondsSinceEpoch / 1000,
-        "endDate": end.millisecondsSinceEpoch / 1000,
+        "startDate": startUtc.millisecondsSinceEpoch / 1000,
+        "endDate": endUtc.millisecondsSinceEpoch / 1000,
         "types": types.map((e) => e.index).toList(),
       },
     );
@@ -176,22 +179,16 @@ List<Album> _jsonToAlbums(dynamic json) {
 }
 
 class GetMediaFileEvent {
-  final String type;
   final String fileId;
   final double progress;
-  final MediaFile file;
 
   GetMediaFileEvent({
-    @required this.type,
     @required this.fileId,
     @required this.progress,
-    @required this.file,
   });
 
   factory GetMediaFileEvent.fromJson(Map<String, dynamic> json) => GetMediaFileEvent(
-        type: json["type"],
         fileId: json["fileId"],
         progress: (json["progress"] as num)?.toDouble(),
-        file: json["file"] != null ? MediaFile.fromJson(json["file"]) : null,
       );
 }


### PR DESCRIPTION
- no longer translating start and end date on iOS end in getAssetsWithDateRange()
- simplified GetMediaFileEvent for getMedieFile progress events
- now ensuring start/end date for getMediaAssets are in UTC